### PR TITLE
is_ascii estimate with simd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ harness = false
 [dependencies]
 encoding_rs = { version = "0.7.2", features = ["simd-accel"] }
 is_utf8 = { git = "https://github.com/gnzlbg/is_utf8" }
+stdsimd = { git = "https://github.com/rust-lang-nursery/stdsimd"}
 
 [dev-dependencies]
 criterion = { version = "0.2.3", features=['real_blackbox'] }

--- a/criterion/validate-utf8.rs
+++ b/criterion/validate-utf8.rs
@@ -18,6 +18,13 @@ macro_rules! bench {
                 Benchmark::new("std", move |b| b.iter(|| ::simd_utf8_check::regular(text)))
                     .with_function("simd", move |b| b.iter(|| ::simd_utf8_check::simd(text)))
                     .with_function("encoding_rs", move |b| b.iter(|| encoding::Encoding::utf8_valid_up_to(text)))
+                    .with_function("simd_or_encoding_rs_with_pre_check", move |b| b.iter(|| {
+                        if ::simd_utf8_check::is_ascii_estimate_simd(text){
+                            encoding::Encoding::utf8_valid_up_to(text) == text.len()
+                        }else{
+                            ::simd_utf8_check::simd(text)
+                        }
+                    }))
                     .with_function("is_utf8", move |b| b.iter(|| ::is_utf8::is_utf8(text)))
                     .with_function("is_utf8_hoehrmann", move |b| b.iter(|| ::is_utf8::is_utf8_hoehrmann(text)))
                     .throughput(Throughput::Bytes(text.len() as u32))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
+#![feature(stdsimd)]
 #![feature(align_offset, test)]
+
+extern crate stdsimd;
 
 mod std_validation;
 mod simd_validation;
@@ -10,4 +13,16 @@ pub use simd_validation::run_utf8_validation as simd;
 pub struct Utf8Error {
     valid_up_to: usize,
     error_len: Option<u8>,
+}
+
+pub fn is_ascii_estimate_simd(utf8_slice: &[u8]) -> bool{
+    if utf8_slice.len() >= 8 {
+        let partial_text = stdsimd::simd::u8x8::load_unaligned(&utf8_slice[..8]);
+        partial_text.le(stdsimd::simd::u8x8::splat(0x7F)).all()
+    }else if utf8_slice.len() >= 4 {
+        let partial_text = stdsimd::simd::u8x4::load_unaligned(&utf8_slice[..4]);
+        partial_text.le(stdsimd::simd::u8x4::splat(0x7F)).all()
+    }else{
+        utf8_slice[..8].iter().all(|&x| x > 0x7F)
+    }
 }


### PR DESCRIPTION
#2 
I added a a check, to see if a String starts/contains ascii. Since the simd version is only faster for a lot of multibyte string, we could also do the switch when `any` of the first characters is ascii instead of `all`.

The check is quite cheap and simd enabled, but most strings are probably quite short, which is not reflected in the tests. So the real impact of this check would be probably bigger than in the benchmarks currently.